### PR TITLE
Feature Additions: Selectability and Quick Create Operation

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,17 +1,33 @@
 chrome.runtime.onInstalled.addListener(() => {
-    chrome.storage.sync.get(["hideEnabled", "lookupMode", "projectEnabled"], (data) => {
+    chrome.storage.sync.get(["hideEnabled",
+                             "selectabilityEnabled",
+                             "createOperationsEnabled",
+                             "lookupMode",
+                             "projectEnabled"], (data) => {
         if (data.hideEnabled === undefined) chrome.storage.sync.set({ hideEnabled: true });
+        if (data.selectabilityEnabled === undefined) chrome.storage.sync.set({ selectabilityEnabled: true });
+        if (data.createOperationsEnabled === undefined) chrome.storage.sync.set({ createOperationsEnabled: false });
         if (!data.lookupMode) chrome.storage.sync.set({ lookupMode: "highlighted" });
         if (data.projectEnabled === undefined) chrome.storage.sync.set({ projectEnabled: true });
     });
 });
 
 chrome.commands.onCommand.addListener((command) => {
-    chrome.storage.sync.get("projectEnabled", (data) => {
-        if (command === "lookup_task") {
-            executeScript("lookup_task.js");
-        } else if (command === "lookup_project" && data.projectEnabled) {
-            executeScript("lookup_project.js");
+    chrome.storage.sync.get(["hideEnabled",
+                             "selectabilityEnabled",
+                             "createOperationsEnabled",
+                             "lookupMode",
+                             "projectEnabled"], (data) => {
+        switch (command) {
+            case "lookup_task": 
+                executeScript("lookup_task.js");
+                break;
+            case "lookup_project":
+                if (data.projectEnabled) executeScript("lookup_project.js");
+                break;
+            case "create_operation_from_clipboard":
+                if (data.createOperationsEnabled) executeScript("create_operation_from_clipboard.js");
+                break;
         }
     });
 });
@@ -25,3 +41,26 @@ function executeScript(scriptFile) {
         });
     });
 }
+
+// Function to update the CSRF token in local storage
+async function updateCsrfToken() {
+  chrome.cookies.get({ url: 'https://app.outlier.ai', name: '_csrf' }, (cookie) => {
+    if (cookie) {
+      chrome.storage.local.set({ csrfToken: decodeURIComponent(cookie.value) }, () => {
+        console.log('CSRF token updated in local storage:', cookie.value);
+      });
+    } else {
+      console.error('CSRF token not found in cookies');
+    }
+  });
+}
+
+// Listen for changes to the CSRF cookie
+chrome.cookies.onChanged.addListener((changeInfo) => {
+  if (changeInfo.cookie.name === '_csrf' && changeInfo.cookie.domain.includes('outlier.ai')) {
+    updateCsrfToken();
+  }
+});
+
+// Initial update of the CSRF token
+updateCsrfToken();

--- a/create_operation_from_clipboard.js
+++ b/create_operation_from_clipboard.js
@@ -80,10 +80,35 @@ async function sendPostRequest() {
         });
 
         if (response.ok) {
-            alert("Request sent successfully!");
+            confirm("Created operation successfully!\n\nClaim operation now?");
+            
+            const responseBody = await response.text();
+            const operationID = JSON.parse(responseBody)["operationIds"][1];
+            alert("Operation ID:"+operationID);
+            const claimRequestBody = {
+                "event": {
+                    "type": "claimAttempt",
+                    "userId": userID
+                }
+            };
+
+            const claimURL = "https://app.outlier.ai/corp-api/qm/operations/"+
+                              operationID+"/transition";
+            const claimResponse = await fetch(claimURL, {
+                method: 'POST',
+                headers: {
+                    "X-CSRF-Token": csrfToken,
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify(claimRequestBody)
+            });
+            location.reload();
+            
+            if (!claimResponse.ok) {
+                throw new Error('Claim operation failed:\n'+response.status+'\n'+response.statusText);
+            }
         } else {
-            console.error('Request failed:', response.status, response.statusText);
-            alert("Request failed: " + response.statusText);
+            throw new Error('Create operation failed:\n'+response.status+'\n'+response.statusText);
         }
     } catch (error) {
         console.error(error);

--- a/create_operation_from_clipboard.js
+++ b/create_operation_from_clipboard.js
@@ -87,37 +87,37 @@ async function sendPostRequest() {
             console.log(responseBody.operationIds[0]);
             const operationID = responseBody.operationIds[0];
             
-            confirm("Created operation successfully!\n\nClaim operation now?");
-            
-            const claimRequestBody = {
-                "event": {
-                    "type": "claimAttempt",
-                    "userId": userID
-                }
-            };
-            console.log(JSON.stringify(claimRequestBody));
-            console.log(userID);
-            const claimURL = "https://app.outlier.ai/corp-api/qm/operations/"+operationID+"/transition";
-            const claimResponse = await fetch(claimURL, {
-                method: 'POST',
-                headers: {
-                    "X-CSRF-Token": csrfToken,
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify(claimRequestBody)
-            });
-            
-            if (claimResponse.ok) {
-                const claimResponseBody = await claimResponse.json();
-                if (claimResponseBody.operation.stateMachine.currentState == "attempt_claimed") {
-                    const operationId = claimResponseBody.operation._id;
-                    const relatedObjectId = claimResponseBody.nodes[0].qaOperation.relatedObjectId;
+            if (confirm("Created operation successfully!\n\nClaim operation now?")) {
+                const claimRequestBody = {
+                    "event": {
+                        "type": "claimAttempt",
+                        "userId": userID
+                    }
+                };
+                console.log(JSON.stringify(claimRequestBody));
+                console.log(userID);
+                const claimURL = "https://app.outlier.ai/corp-api/qm/operations/"+operationID+"/transition";
+                const claimResponse = await fetch(claimURL, {
+                    method: 'POST',
+                    headers: {
+                        "X-CSRF-Token": csrfToken,
+                        "Content-Type": "application/json"
+                    },
+                    body: JSON.stringify(claimRequestBody)
+                });
+                
+                if (claimResponse.ok) {
+                    const claimResponseBody = await claimResponse.json();
+                    if (claimResponseBody.operation.stateMachine.currentState == "attempt_claimed") {
+                        const operationId = claimResponseBody.operation._id;
+                        const relatedObjectId = claimResponseBody.nodes[0].qaOperation.relatedObjectId;
                     open("https://app.outlier.ai/en/expert/outlieradmin/tools/chat_bulk_audit/"+relatedObjectId+"?closeOnComplete=1&qaOperationId="+operationId,"_blank","toolbar=0, location=0, menubar=0, addressbar=0");
+                    } else {
+                        throw new Error('Failed to claim operation.');
+                    }    
                 } else {
-                    throw new Error('Failed to claim operation.');
-                }    
-            } else {
-                throw new Error('Claim operation failed:\n'+response.status+'\n'+response.statusText);
+                    throw new Error('Claim operation failed:\n'+response.status+'\n'+response.statusText);
+                }
             }
         } else {
             throw new Error('Create operation failed:\n'+response.status+'\n'+response.statusText);

--- a/create_operation_from_clipboard.js
+++ b/create_operation_from_clipboard.js
@@ -1,0 +1,105 @@
+(async () => {
+    try {
+        sendPostRequest();
+    } catch (error) {
+        alert("Error: " + error);
+    }
+})();
+
+async function sendPostRequest() {
+    try {
+        // Read from clipboard
+        const clipboardText = await navigator.clipboard.readText();
+        if (!clipboardText.match(/^[A-Za-z0-9]{24}(\n[A-Za-z0-9]{24})*$/g)) {
+            throw new Error("Clipboard is not a clean list of IDs.\nClipboard content:\n"
+                           +clipboardText);
+        }
+        const relatedIds = clipboardText.split('\n').filter(id => id.trim() !== '');
+        
+        // Calculate maxTimeRequired and dueDate
+        const MINUTES_PER_TASK = 12;
+        const maxTimeRequired = relatedIds.length * MINUTES_PER_TASK * 60; // 12 minutes per ID
+        const dueDate = new Date();
+        dueDate.setDate(dueDate.getDate() + 1);
+        const dueDateString = dueDate.toISOString();
+        
+        // Get CSRF token from cookies
+        const csrfToken = await getCsrfToken();
+
+        // Get user ID
+        const userID = localStorage.getItem("ajs_user_id")
+        
+        // Get activeWorkerTeam ID
+        const activeWorkerTeam = JSON.parse(localStorage.getItem("ajs_user_traits"))["activeWorkerTeam"]
+        
+        // Get workerName for default task name
+        const workerName = JSON.parse(localStorage.getItem("ajs_user_traits"))["firstName"]
+        
+        // Prompt for the name
+        const name = prompt("Enter the name for the operation:",workerName);
+        if (name === null) {
+            alert("Cancelled creation of operation.")
+            return;
+        }
+        
+        // Prepare the request body
+        const requestBody = {
+            operation: {
+                type: "speed_audit",
+                name: name,
+                priority: 3,
+                maxTimeRequired: maxTimeRequired,
+                project: "",
+                dueDate: dueDateString,
+                params: {
+                    auditBatchView: "chat_bulk_audit",
+                    instructions: ""
+                },
+                context: {
+                    assignmentParams: {
+                        userIds: [],
+                        workerTeamIds: [activeWorkerTeam]
+                    },
+                    reviewAssignmentParams: {
+                        userIds: [userID],
+                        workerTeamIds: []
+                    }
+                }
+            },
+            relatedIds: relatedIds
+        };
+        
+        // Send the POST request
+        const response = await fetch('https://app.outlier.ai/corp-api/qm/operations/batch', {
+            method: 'POST',
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(requestBody)
+        });
+
+        if (response.ok) {
+            alert("Request sent successfully!");
+        } else {
+            console.error('Request failed:', response.status, response.statusText);
+            alert("Request failed: " + response.statusText);
+        }
+    } catch (error) {
+        console.error(error);
+        alert(error);
+    }
+}
+
+function getCsrfToken() {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get('csrfToken', (data) => {
+      const csrfToken = data.csrfToken;
+      if (csrfToken) {
+        resolve(csrfToken);
+      } else {
+        reject('CSRF token not found in local storage');
+      }
+    });
+  });
+}

--- a/delimiter_tooltip.js
+++ b/delimiter_tooltip.js
@@ -1,0 +1,83 @@
+(function() {
+    if (!chrome.storage.sync.get("delimiterTooltipsEnabled")) return;
+    const cssText = `
+        math-inline.math-node {
+            position: relative;
+            display: inline-block;
+        }
+
+        math-inline.math-node::before {
+            content: attr(open) ' ' attr(close);
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: #333;
+            color: white;
+            padding: 5px 10px;
+            border-radius: 4px;
+            font-size: 14px;
+            font-family: monospace;
+            white-space: nowrap;
+            margin-bottom: 5px;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease-in-out;
+            z-index: 10000;
+        }
+
+        math-inline.math-node:hover::before {
+            opacity: 1;
+        }
+    `;
+    
+    // Inject into main document
+    const mainStyle = document.createElement('style');
+    mainStyle.textContent = cssText;
+    document.head.appendChild(mainStyle);
+    
+    // Function to inject styles into shadow roots
+    function injectIntoShadowRoots() {
+        // Find all elements that might have shadow roots
+        document.querySelectorAll('*').forEach(element => {
+	    if (element.shadowRoot) {
+                // Check if we already injected styles
+                if (!element.shadowRoot.querySelector('.math-inline-tooltip-styles')) {
+		    const shadowStyle = document.createElement('style');
+		    shadowStyle.className = 'math-inline-tooltip-styles';
+		    shadowStyle.textContent = cssText;
+		    element.shadowRoot.appendChild(shadowStyle);
+                }
+	    }
+        });
+    }
+    
+    // Initial injection
+    injectIntoShadowRoots();
+    
+    // Watch for new shadow roots
+    const observer = new MutationObserver((mutations) => {
+        injectIntoShadowRoots();
+    });
+    
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true
+    });
+    
+    // Also catch shadow roots that might be created after our observer starts
+    const originalAttachShadow = Element.prototype.attachShadow;
+    Element.prototype.attachShadow = function(...args) {
+        const shadowRoot = originalAttachShadow.apply(this, args);
+        
+        // Inject our styles into the new shadow root
+        setTimeout(() => {
+	    const shadowStyle = document.createElement('style');
+	    shadowStyle.className = 'math-inline-tooltip-styles';
+	    shadowStyle.textContent = cssText;
+	    shadowRoot.appendChild(shadowStyle);
+        }, 0);
+        
+        return shadowRoot;
+    };
+})();

--- a/delimiter_tooltip.js
+++ b/delimiter_tooltip.js
@@ -1,5 +1,8 @@
-(function() {
-    if (!chrome.storage.sync.get("delimiterTooltipsEnabled")) return;
+(async function() {
+    const settings = await chrome.storage.sync.get();
+    console.log("settings",settings);
+
+    if (!settings.delimiterTooltipsEnabled) return;
     const cssText = `
         math-inline.math-node {
             position: relative;

--- a/hide_external_feedback.js
+++ b/hide_external_feedback.js
@@ -9,7 +9,7 @@
         const grandparentDiv = result.singleNodeValue;
         if (grandparentDiv) {
             // Remove the grandparent <div>
-            grandparentDiv.style.display = chrome.storage.sync.get("hideEnabled") ? 'none' : ''; 
+            grandparentDiv.style.display = 'none'; 
         }
     }
 
@@ -29,7 +29,7 @@
     const observer = new MutationObserver((mutations) => {
         // For every mutation, attempt to hide the target div
         mutations.forEach(() => {
-            hideTargetDiv();
+            if (chrome.storage.sync.get("hideEnabled")) hideTargetDiv();
             if (chrome.storage.sync.get("selectabilityEnabled")) makeAllSelectable();
         });
     });

--- a/hide_external_feedback.js
+++ b/hide_external_feedback.js
@@ -1,5 +1,3 @@
-
-
 (function() {
     // Function to hide target div 
     function hideTargetDiv() {
@@ -15,14 +13,24 @@
         }
     }
 
+    function makeAllSelectable() {
+        let elements = document.querySelectorAll('.select-none');
+    
+        for (element of elements) {
+            element.style.userSelect = 'text'; 
+        }
+    }
+
     // Run hide function once at load
     hideTargetDiv();
+    makeAllSelectable();
 
     // Set up a MutationObserver to watch for changes in the DOM.
     const observer = new MutationObserver((mutations) => {
         // For every mutation, attempt to hide the target div
         mutations.forEach(() => {
             hideTargetDiv();
+            if (chrome.storage.sync.get("selectabilityEnabled")) makeAllSelectable();
         });
     });
 

--- a/hide_external_feedback.js
+++ b/hide_external_feedback.js
@@ -1,4 +1,4 @@
-(function() {
+(async function() {
     // Function to hide target div 
     function hideTargetDiv() {
         // Use XPath to find the grandparent <div> of the <p> element with the exact text
@@ -21,16 +21,20 @@
         }
     }
 
+    
+    const settings = await chrome.storage.sync.get();
+    console.log("settings",settings);
+
     // Run hide function once at load
-    hideTargetDiv();
-    makeAllSelectable();
+    if (settings.hideEnabled) hideTargetDiv();
+    if (settings.selectabilityEnabled) makeAllSelectable();
 
     // Set up a MutationObserver to watch for changes in the DOM.
     const observer = new MutationObserver((mutations) => {
         // For every mutation, attempt to hide the target div
         mutations.forEach(() => {
-            if (chrome.storage.sync.get("hideEnabled")) hideTargetDiv();
-            if (chrome.storage.sync.get("selectabilityEnabled")) makeAllSelectable();
+            if (settings.hideEnabled) hideTargetDiv();
+            if (settings.selectabilityEnabled) makeAllSelectable();
         });
     });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Audit Tools",
-    "version": "2.2",
+    "version": "2.3",
     "description": "Tools for auditors (Scale QC team)",
     "permissions": ["tabs", "scripting", "storage", "activeTab","cookies"],
     "background": {
@@ -39,7 +39,11 @@
     "content_scripts": [
         {
             "matches": ["https://app.outlier.ai/en/expert/outlieradmin/tools/chat_bulk_audit/*"],
-            "js": ["hide_external_feedback.js"]
+            "js": ["hide_external_feedback.js","delimiter_tooltip.js"]
+        },
+	{
+            "matches": ["https://app.outlier.ai/en/expert/outlieradmin/tools/chat_bulk_audit/*","https://app.outlier.ai/en/expert/outlieradmin/tools/lookup/*"],
+            "js": ["delimiter_tooltip.js"]
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
     "content_scripts": [
         {
             "matches": ["https://app.outlier.ai/en/expert/outlieradmin/tools/chat_bulk_audit/*"],
-            "js": ["hide_external_feedback.js","delimiter_tooltip.js"]
+            "js": ["hide_external_feedback.js"]
         },
 	{
             "matches": ["https://app.outlier.ai/en/expert/outlieradmin/tools/chat_bulk_audit/*","https://app.outlier.ai/en/expert/outlieradmin/tools/lookup/*"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
     "manifest_version": 3,
     "name": "Audit Tools",
-    "version": "2.1",
+    "version": "2.2",
     "description": "Tools for auditors (Scale QC team)",
-    "permissions": ["tabs", "scripting", "storage", "activeTab"],
+    "permissions": ["tabs", "scripting", "storage", "activeTab","cookies"],
     "background": {
         "service_worker": "background.js"
     },
@@ -19,6 +19,12 @@
                 "default": "Alt+K"
             },
             "description": "Looks up project in OpsHub by ID"
+        },
+        "create_operation_from_clipboard": {
+            "suggested_key": {
+                "default": "Alt+O"
+            },
+            "description": "Creates batch operation from clipboard IDs" 
         }
     },
     "host_permissions": ["<all_urls>"],

--- a/popup.html
+++ b/popup.html
@@ -33,7 +33,14 @@
             <span class="toggle-slider"></span>
             <span class="toggle-label">Create ops with &lt;Alt+O&gt;</span>
         </label>
-        
+	
+	<label class="toggle-container">
+            &emsp;&emsp;
+            <input type="checkbox" id="delimiterTooltipsEnabled">
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">Show delimiter tooltips</span>
+        </label>
+	
         <label for="lookupMode">Lookup with &lt;Alt+L&gt;</label>
             &emsp;&emsp;
             <select id="lookupMode">

--- a/popup.html
+++ b/popup.html
@@ -20,6 +20,20 @@
             <span class="toggle-label">Hide "External Feedback"</span>
         </label>
 
+        <label class="toggle-container">
+            &emsp;&emsp;
+            <input type="checkbox" id="selectabilityEnabled">
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">Make all prompts selectable</span>
+        </label>
+
+        <label class="toggle-container">
+            &emsp;&emsp;
+            <input type="checkbox" id="createOperationsEnabled">
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">Create ops with &lt;Alt+O&gt;</span>
+        </label>
+        
         <label for="lookupMode">Lookup with &lt;Alt+L&gt;</label>
             &emsp;&emsp;
             <select id="lookupMode">

--- a/popup.js
+++ b/popup.js
@@ -1,16 +1,28 @@
 document.addEventListener("DOMContentLoaded", () => {
-    chrome.storage.sync.get(["hideEnabled", "lookupMode", "projectEnabled"], (data) => {
+    chrome.storage.sync.get(["hideEnabled",
+                             "selectabilityEnabled",
+                             "createOperationsEnabled",
+                             "lookupMode",
+                             "projectEnabled"], (data) => {
         document.getElementById("hideEnabled").checked = data.hideEnabled;
+        document.getElementById("selectabilityEnabled").checked = data.selectabilityEnabled;
+        document.getElementById("createOperationsEnabled").checked = data.createOperationsEnabled;
         document.getElementById("lookupMode").value = data.lookupMode || "clipboard";
         document.getElementById("projectEnabled").checked = data.projectEnabled;
     });
 
     document.getElementById("save").addEventListener("click", () => {
         const hideEnabled = document.getElementById("hideEnabled").checked;
+        const selectabilityEnabled = document.getElementById("selectabilityEnabled").checked;
+        const createOperationsEnabled = document.getElementById("createOperationsEnabled").checked;
         const lookupMode = document.getElementById("lookupMode").value;
         const projectEnabled = document.getElementById("projectEnabled").checked;
 
-        chrome.storage.sync.set({ hideEnabled, lookupMode, projectEnabled }, () => {
+        chrome.storage.sync.set({hideEnabled,
+                                 selectabilityEnabled,
+                                 createOperationsEnabled,
+                                 lookupMode,
+                                 projectEnabled}, () => {
             alert("Settings saved!");
         });
     });

--- a/popup.js
+++ b/popup.js
@@ -3,12 +3,14 @@ document.addEventListener("DOMContentLoaded", () => {
                              "selectabilityEnabled",
                              "createOperationsEnabled",
                              "lookupMode",
-                             "projectEnabled"], (data) => {
+                             "projectEnabled",
+			     "delimiterTooltipsEnabled"], (data) => {
         document.getElementById("hideEnabled").checked = data.hideEnabled;
         document.getElementById("selectabilityEnabled").checked = data.selectabilityEnabled;
         document.getElementById("createOperationsEnabled").checked = data.createOperationsEnabled;
         document.getElementById("lookupMode").value = data.lookupMode || "clipboard";
         document.getElementById("projectEnabled").checked = data.projectEnabled;
+        document.getElementById("delimiterTooltipsEnabled").checked = data.delimiterTooltipsEnabled;
     });
 
     document.getElementById("save").addEventListener("click", () => {
@@ -17,12 +19,13 @@ document.addEventListener("DOMContentLoaded", () => {
         const createOperationsEnabled = document.getElementById("createOperationsEnabled").checked;
         const lookupMode = document.getElementById("lookupMode").value;
         const projectEnabled = document.getElementById("projectEnabled").checked;
-
+	const delimiterTooltipsEnabled = document.getElementById("delimiterTooltipsEnabled").checked;
         chrome.storage.sync.set({hideEnabled,
                                  selectabilityEnabled,
                                  createOperationsEnabled,
                                  lookupMode,
-                                 projectEnabled}, () => {
+                                 projectEnabled,
+				 delimiterTooltipsEnabled}, () => {
             alert("Settings saved!");
         });
     });


### PR DESCRIPTION
This pull requests adds toggle-able features to audit-tools.

1.  All text boxes in outlier can be made selectable. Copy-Paste is dead. Long live Copy-Paste. On by default.
2.  Operations can be created directly from a list of attempt IDs in the clipboard with `Alt+O`. Doing this prompts for an operation name, and if the request is successful gives an option to automatically claim and open the operation. Off by default.
![image](https://github.com/user-attachments/assets/80eaaad5-bf31-41c0-b4ad-34961a0b85e9)