### PR TITLE
adds Alt-A attempt lookup by related object id

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,6 +28,9 @@ chrome.commands.onCommand.addListener((command) => {
             case "create_operation_from_clipboard":
                 if (data.createOperationsEnabled) executeScript("create_operation_from_clipboard.js");
                 break;
+            case "lookup_attempt":
+                executeScript("lookup_attempt.js");
+                break;
         }
     });
 });

--- a/lookup_attempt.js
+++ b/lookup_attempt.js
@@ -1,0 +1,62 @@
+function getSelectedText() {
+    return window.getSelection().toString().trim();
+}
+
+function getCsrfToken() {
+    return new Promise((resolve, reject) => {
+        chrome.storage.local.get('csrfToken', (data) => {
+            const csrfToken = data.csrfToken;
+            if (csrfToken) {
+                resolve(csrfToken);
+            } else {
+                reject('CSRF token not found in local storage');
+            }
+        });
+    });
+}
+
+async function lookupAttempt() {
+    chrome.storage.sync.get('lookupMode', async (data) => {
+        const mode = data.lookupMode || 'clipboard';
+        let relatedObjectId;
+
+        if (mode === 'clipboard') {
+            relatedObjectId = await navigator.clipboard.readText();
+        } else {
+            relatedObjectId = getSelectedText();
+        }
+        relatedObjectId = relatedObjectId.trim();
+
+        if (relatedObjectId) {
+            try {
+                const csrfToken = await getCsrfToken();
+                const url = `https://app.outlier.ai/corp-api/chatBulkAudit/attemptAudit/${relatedObjectId}`;
+                
+                const response = await fetch(url, {
+                    method: 'GET',
+                    headers: {
+                        'Accept': '*/*',
+                        'X-CSRF-Token': csrfToken,
+                    },
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const responseData = await response.json();
+                if (responseData && responseData.length > 0 && responseData[0].auditedEntityContext && responseData[0].auditedEntityContext.entityAttemptId) {
+                    const attemptId = responseData[0].auditedEntityContext.entityAttemptId;
+                    window.open(`https://app.outlier.ai/en/expert/outlieradmin/tools/lookup/${attemptId}#View%20Responses`, '_blank');
+                } else {
+                    alert('Could not find attempt ID for the given related object ID.');
+                }
+            } catch (error) {
+                console.error('Error looking up attempt:', error);
+                alert('Error looking up attempt: ' + error.message);
+            }
+        }
+    });
+}
+
+lookupAttempt();

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
     "manifest_version": 3,
     "name": "Audit Tools",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Tools for auditors (Scale QC team)",
-    "permissions": ["tabs", "scripting", "storage", "activeTab","cookies"],
+    "permissions": ["scripting", "storage", "activeTab", "cookies"],
     "background": {
         "service_worker": "background.js"
     },
@@ -25,6 +25,12 @@
                 "default": "Alt+O"
             },
             "description": "Creates batch operation from clipboard IDs" 
+        },
+        "lookup_attempt": {
+            "suggested_key": {
+                "default": "Alt+A"
+            },
+            "description": "Looks up task attempt by related object ID"
         }
     },
     "host_permissions": ["<all_urls>"],

--- a/popup.html
+++ b/popup.html
@@ -41,7 +41,13 @@
             <span class="toggle-label">Show delimiter tooltips</span>
         </label>
 	
-        <label for="lookupMode">Lookup with &lt;Alt+L&gt;</label>
+        <label for="lookupMode">
+	  Lookup with
+	  <ul>
+	    <li>&lt;Alt+L&gt; (by Attempt ID)</li>
+	    <li>&lt;Alt+A&gt; (by Related Object ID)</li>
+	  </ul>
+	</label>
             &emsp;&emsp;
             <select id="lookupMode">
                 <option value="clipboard">from clipboard</option>


### PR DESCRIPTION
This adds a command to lookup an attempt using the Related Object Id as present in the Outlier task queue.

- The command is bound by default to `<Alt-A>`
- It sources the Related Object Id using the same setting as the original lookup command (I.e., clipboard vs highlighted text)

> [!CAUTION]
>  It is unknown what the behavior will be for an operation containing multiple attempts.